### PR TITLE
feat: clear redirect params

### DIFF
--- a/lib/HttpLoginHandler.ts
+++ b/lib/HttpLoginHandler.ts
@@ -40,6 +40,9 @@ export class HttpLoginHandler {
           this.session.handleIncomingRedirect(`http://localhost:${this.port}${req.url}`)
             .then(resolve, reject);
           res.writeHead(200);
+          res.end(`<script>window.location = new URL('http://localhost:${this.port}/done'); window.close();</script>`);
+        } else if (req.url!.startsWith('/done')) {
+          res.writeHead(200);
           res.end(`<script>window.close();</script>`);
         } else {
           res.writeHead(404);

--- a/test/HttpLoginHandler.test.ts
+++ b/test/HttpLoginHandler.test.ts
@@ -49,6 +49,10 @@ describe('HttpLoginHandler', () => {
         requestHandler({
           url: '/onLoggedIn',
         }, res);
+
+        requestHandler({
+          url: '/done',
+        }, res);
       }),
       info: {
         isLoggedIn: true,
@@ -74,7 +78,24 @@ describe('HttpLoginHandler', () => {
       expect(open).toHaveBeenCalledWith('http://example.org/authenticate');
       expect(session.handleIncomingRedirect).toHaveBeenCalledWith('http://localhost:3005/onLoggedIn');
       expect(res.writeHead).toHaveBeenCalledWith(200);
-      expect(res.end).toHaveBeenCalledWith('<script>window.close();</script>');
+      expect(res.end).toHaveBeenCalledWith(
+        '<script>window.location = new URL(\'http://localhost:3005/done\'); window.close();</script>',
+      );
+
+      expect(server.close).toHaveBeenCalledWith();
+      expect(socket.destroy).toHaveBeenCalledWith();
+
+      await open('http://localhost:3005/done');
+    });
+
+    it('handles a valid post-login sequence', async() => {
+      await handler.handleLogin({});
+
+      await open('http://localhost:3005/done');
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+      expect(res.end).toHaveBeenCalledWith(
+        '<script>window.close();</script>',
+      );
 
       expect(server.close).toHaveBeenCalledWith();
       expect(socket.destroy).toHaveBeenCalledWith();
@@ -98,7 +119,9 @@ describe('HttpLoginHandler', () => {
       expect(handleRedirect).toHaveBeenCalledWith('http://example.org/authenticate');
       expect(session.handleIncomingRedirect).toHaveBeenCalledWith('http://localhost:3005/onLoggedIn');
       expect(res.writeHead).toHaveBeenCalledWith(200);
-      expect(res.end).toHaveBeenCalledWith('<script>window.close();</script>');
+      expect(res.end).toHaveBeenCalledWith(
+        '<script>window.location = new URL(\'http://localhost:3005/done\'); window.close();</script>',
+      );
 
       expect(server.close).toHaveBeenCalledWith();
       expect(socket.destroy).toHaveBeenCalledWith();


### PR DESCRIPTION
Avoid keeping the `code` parameter in the URL after redirect.